### PR TITLE
Align cloned folder name with plugin name (fix #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ by foregoing higher-than-sufficient quality levels.
 
 1. Read [Oh My Zsh's notes on custom plugins](https://github.com/ohmyzsh/ohmyzsh#custom-plugins-and-themes)
 1. `cd $ZSH_CUSTOM`
-1. `git clone https://github.com/katrinleinweber/oh-my-zsh-youtube-dl-aliases`
+1. `git clone https://github.com/katrinleinweber/oh-my-zsh-youtube-dl-aliases youtube-dl`
 1. Add `youtube-dl` to your `~/.zshrc` file's `plugins=(…)` list
 1. Restart your shell
 


### PR DESCRIPTION
Hi @faucetsr 👋 Apologies for the late reply to #2. I think this detail was missing from my instructions. Could you please try renaming the cloned folder?

Alternatively, add `oh-my-zsh-youtube-dl-aliases` to your `~/.zshrc` file's `plugins=(…)` list ;-)